### PR TITLE
Add customization option for Ranking and Fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,21 @@ Will be updated when the entry in the plugin directory is ready
 The SAMS XML-interface is described in the following wiki:
 [XML Schnittstelle](http://wiki.sams-server.de/wiki/XML-Schnittstelle#Spielplan_und_Ergebnisse)
 
+
+## Customizing Ranking and Fixtures
+
+Since version 1.2.0 you are able to override the default representation of the ranking and the fixtures view.
+
+Just add a new template file to the folder of your currently used theme:
+
+* Ranking: `sams-integration/ranking-template.php`
+* Fixtures: `sams-integration/fixtures-template.php`
+
+You can find the default implementation in the `sams-integration/build/php/templates/` folder to get a starting point how things are working.
+
+Perhaps some additional customizations will be added in the future (e.g. the format of the fixtures venues).
+
+
 ## License
 This piece of modern art is published with a GNU GPLv2 license. I will not take charge of any harm, damages or data losses that could be caused by this plugin. Use it on your own risk.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "sams-integration",
-	"version": "1.0.1",
+	"version": "1.2.0",
 	"description": "Displays fixtures and results from a SAMS results system",
 	"author": "René Siemer",
 	"license": "GPL-2.0-or-later",

--- a/release-plugin-directory/trunk/readme.txt
+++ b/release-plugin-directory/trunk/readme.txt
@@ -3,7 +3,7 @@ Contributors:      renao
 Tags:              block
 Tested up to:      6.8
 Requires at least: 5.6.0
-Stable tag:        1.0.1
+Stable tag:        1.2.0
 License:           GPL-2.0-or-later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -24,6 +24,18 @@ confederation. I got mine from the WVV (Westdeutscher Volleyballverband).
 1. Upload the plugin files to the `/wp-content/plugins/sams-integration` directory, or install the plugin through the WordPress plugins screen directly.
 1. Activate the plugin through the 'Plugins' screen in WordPress
 
+== Customization ==
+
+Since version 1.2.0 you are able to override the default representation of the ranking and the fixtures view.
+
+Just add a new template file to the folder of your currently used theme:
+
+* Ranking: `sams-integration/ranking-template.php`
+* Fixtures: `sams-integration/fixtures-template.php`
+
+You can find the default implementation in the `sams-integration/build/php/templates/` folder to get a starting point how things are working.
+
+Perhaps some additional customizations will be added in the future (e.g. the format of the fixtures venues).
 
 == Frequently Asked Questions ==
 
@@ -38,6 +50,10 @@ If you or your club is a member of a regional confederation you can get this API
 3. (example) Rendered fixtures integrated to a sample page
 
 == Changelog ==
+
+= 1.2.0 =
+* Add customazation options for ranking and fixtures
+* Fix broken br-tag in fixture venue
 
 = 1.0.1 =
 * Upgrade dependencies

--- a/sams-integration.php
+++ b/sams-integration.php
@@ -34,3 +34,16 @@ function samsintegration_initialize_blocktypes() {
 	register_block_type( __DIR__ . '/build/blocks/sams-fixtures' );
 }
 add_action( 'init', 'samsintegration_initialize_blocktypes' );
+
+function sams_integration_get_template( $template_name ) {
+    $theme_template = locate_template( 'sams-integration/' . $template_name );
+    
+    if ( ! empty( $theme_template ) ) {
+        // if exists: use template from theme
+        return $theme_template;
+    } else {
+        // fallback on default template
+        return plugin_dir_path( __FILE__ ) . 'build/php/templates/' . $template_name;
+    }
+}
+

--- a/sams-integration.php
+++ b/sams-integration.php
@@ -4,7 +4,7 @@
  * Description:       Displays fixtures and rankings from a SAMS results system
  * Requires at least: 5.6
  * Requires PHP:      7.2
- * Version:           1.0.1
+ * Version:           1.2.0
  * Author:            René Siemer
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/src/blocks/sams-fixtures/block.json
+++ b/src/blocks/sams-fixtures/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "renao/sams-fixtures",
-	"version": "1.0.0",
+	"version": "1.2.0",
 	"title": "SAMS Fixtures",
 	"category": "widgets",
 	"icon": "analytics",

--- a/src/blocks/sams-fixtures/render.php
+++ b/src/blocks/sams-fixtures/render.php
@@ -3,8 +3,12 @@
  * @see https://github.com/WordPress/gutenberg/blob/trunk/docs/reference-guides/block-api/block-metadata.md#render
  */
 
-
 use SAMSPlugin\FixturesFetcher;
+?>
+
+<div <?php echo get_block_wrapper_attributes(); ?>>
+
+<?php
 
 if (isset($attributes)
 	&& isset($attributes['apiKey'])
@@ -18,39 +22,20 @@ if (isset($attributes)
 		$attributes['apiKey'],
 		$attributes['matchSeriesId'],
 		$attributes['teamId']);
-?>
-
-<div <?php echo get_block_wrapper_attributes(); ?>>
-<table class="sams-fixtures">
-    <th class="date"><?php esc_html_e('Starts', 'sams-integration'); ?></th>
-    <th class="fixtureName"><?php esc_html_e('Fixture', 'sams-integration'); ?></th>
-    <th class="venue"><?php esc_html_e('Venue', 'sams-integration'); ?></th>
-    
 	
-	<?php foreach ($fixtures->fixturesEntries as $fixture) { ?>
+	$template_path = sams_integration_get_template( 'fixtures-template.php' );
 
-	<tr>
-    <td class="date">
-		<?php echo esc_html($fixture->date); ?>
-        <br>
-		<?php echo esc_html($fixture->startTime); ?> Uhr
-    </td>
-    <td class="fixture">
-		<span class="fixture-name"> <?php echo esc_html($fixture->teamHome . " - " . $fixture->teamAway); ?></span>
-		<span class="fixture-result"><?php if ($fixture->hasResult()) { echo esc_html(" (" . $fixture->score . ")"); }; ?></span>
-	</td>
-    <td class="venue"><?php echo esc_html($fixture->venue); ?></td>
-</tr>
+	if (file_exists($template_path)) {
+		$sams_integration_fixtures = $fixtures;
+		include $template_path;
+	}
 
-<?php };?>
-</table>
-
-<?php
 } else {
 	// Display error message on invalid configuration
 	esc_html_e('Error in SAMS Fixtures: Configuration missing or incomplete', 'sams-integration');
 }
-	?>
+
+?>
 
 </div>
 

--- a/src/blocks/sams-ranking/block.json
+++ b/src/blocks/sams-ranking/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "renao/sams-ranking",
-	"version": "1.0.0",
+	"version": "1.2.0",
 	"title": "SAMS Ranking",
 	"category": "widgets",
 	"icon": "analytics",

--- a/src/blocks/sams-ranking/render.php
+++ b/src/blocks/sams-ranking/render.php
@@ -3,7 +3,12 @@
  * @see https://github.com/WordPress/gutenberg/blob/trunk/docs/reference-guides/block-api/block-metadata.md#render
  */
 
- use SAMSPlugin\RankingFetcher;
+use SAMSPlugin\RankingFetcher;
+?>
+
+<div <?php echo get_block_wrapper_attributes(); ?>>
+
+<?php
 
 if (isset($attributes)
 	&& isset($attributes['apiKey'])
@@ -12,36 +17,18 @@ if (isset($attributes)
 
 	$fetcher = new RankingFetcher();
 	$ranking = $fetcher->fetch($attributes['associationUrl'], $attributes['apiKey'], $attributes['matchSeriesId']);
-?>
 
-<div <?php echo get_block_wrapper_attributes(); ?>>
-<table class="sams-ranking">
-    <th class="rank"><?php esc_html_e('Rank', 'sams-integration'); ?></th>
-    <th class="teamName"><?php esc_html_e('Team', 'sams-integration'); ?></th>
-    <th class="games"><?php esc_html_e('Games', 'sams-integration'); ?></th>
-    <th class="balls"><?php esc_html_e('Balls', 'sams-integration'); ?></th>
-    <th class="sets"><?php esc_html_e('Sets', 'sams-integration'); ?></th>
-    <th class="points"><?php esc_html_e('Points', 'sams-integration'); ?></th>
+	$template_path = sams_integration_get_template( 'ranking-template.php' );
 
-	<?php foreach ($ranking->rankingEntries as $entry) { ?>
+	if (file_exists($template_path)) {
+		$sams_integration_ranking = $ranking;
+		include $template_path;
+	}
 
-	<tr>
-		<td class="rank"><?php echo esc_html($entry->place); ?></td>
-		<td class="teamName"><?php echo esc_html($entry->teamName); ?></td>
-		<td class="games"><?php echo esc_html($entry->games); ?></td>
-		<td class="balls"><?php echo esc_html($entry->ballsPro . ':' . $entry->ballsCon); ?></td>
-		<td class="sets"><?php echo esc_html($entry->setsPro . ':' . $entry->setsCon); ?></td>
-		<td class="points"><?php echo esc_html($entry->points); ?></td>
-	</tr>
-
-	<?php };?>
-	</table>
-
-<?php
 } else {
 	// Display error message on invalid configuration
 	esc_html_e('Error in SAMS Ranking: Configuration missing or incomplete', 'sams-integration');
 }
-	?>
+?>
 
 </div>

--- a/src/php/Models/FixturesEntry.php
+++ b/src/php/Models/FixturesEntry.php
@@ -36,12 +36,13 @@ class FixturesEntry {
 
     private function composeLocationName($locationNode) {
         return $locationNode->name 
-        . "<br>" 
+        . " (" 
         . $locationNode->street
-        . "<br>"
+        . ", "
         . $locationNode->postalCode
         . " "
-        . $locationNode->city;
+        . $locationNode->city
+        . ")";
     }
 }
 ?>

--- a/src/php/templates/fixtures-template.php
+++ b/src/php/templates/fixtures-template.php
@@ -1,0 +1,22 @@
+<table class="sams-fixtures">
+    <th class="date"><?php esc_html_e('Starts', 'sams-integration'); ?></th>
+    <th class="fixtureName"><?php esc_html_e('Fixture', 'sams-integration'); ?></th>
+    <th class="venue"><?php esc_html_e('Venue', 'sams-integration'); ?></th>
+    <tbody>
+	
+<?php foreach ($sams_integration_fixtures->fixturesEntries as $fixture) { ?>
+        <tr>
+            <td class="date">
+                <?php echo esc_html($fixture->date); ?>
+                <br>
+                <?php echo esc_html($fixture->startTime); ?> Uhr
+            </td>
+            <td class="fixture">
+                <span class="fixture-name"> <?php echo esc_html($fixture->teamHome . " - " . $fixture->teamAway); ?></span>
+                <span class="fixture-result"><?php if ($fixture->hasResult()) { echo esc_html(" (" . $fixture->score . ")"); }; ?></span>
+            </td>
+            <td class="venue"><?php echo esc_html($fixture->venue); ?></td>
+        </tr>
+<?php };?>
+    </tbody>
+</table>

--- a/src/php/templates/ranking-template.php
+++ b/src/php/templates/ranking-template.php
@@ -1,0 +1,23 @@
+<table class="sams-ranking">
+    <th class="rank"><?php esc_html_e('Rank', 'sams-integration'); ?></th>
+    <th class="teamName"><?php esc_html_e('Team', 'sams-integration'); ?></th>
+    <th class="games"><?php esc_html_e('Games', 'sams-integration'); ?></th>
+    <th class="balls"><?php esc_html_e('Balls', 'sams-integration'); ?></th>
+    <th class="sets"><?php esc_html_e('Sets', 'sams-integration'); ?></th>
+    <th class="points"><?php esc_html_e('Points', 'sams-integration'); ?></th>
+    <tbody>
+
+<?php foreach ($sams_integration_ranking->rankingEntries as $entry) { ?>
+
+        <tr>
+            <td class="rank"><?php echo esc_html($entry->place); ?></td>
+            <td class="teamName"><?php echo esc_html($entry->teamName); ?></td>
+            <td class="games"><?php echo esc_html($entry->games); ?></td>
+            <td class="balls"><?php echo esc_html($entry->ballsPro . ':' . $entry->ballsCon); ?></td>
+            <td class="sets"><?php echo esc_html($entry->setsPro . ':' . $entry->setsCon); ?></td>
+            <td class="points"><?php echo esc_html($entry->points); ?></td>
+        </tr>
+
+<?php };?>
+    </tbody>
+</table>


### PR DESCRIPTION
Extract the template for `Ranking` and `Fixtures` to its each own template file and add mechanism to override the default template from your current theme folder.